### PR TITLE
Add support for importing module types within the same package #12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.3
+---
+
+  * Also allow extraction of module types from the current module's interface file.
+
 1.2
 ---
 

--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "ppx_import"
-version: "1.2"
+version: "1.3"
 maintainer: "whitequark <whitequark@whitequark.org>"
 authors: [ "whitequark <whitequark@whitequark.org>" ]
 license: "MIT"

--- a/src/ppx_import.cppo.ml
+++ b/src/ppx_import.cppo.ml
@@ -315,8 +315,12 @@ let module_type mapper modtype_decl =
     begin match payload with
     | PTyp ({ ptyp_desc = Ptyp_package({ txt = lid; loc } as alias, subst) }) ->
       if Ast_mapper.tool_name () = "ocamldep" then
-        (* Just put it as alias *)
-        { modtype_decl with pmty_desc = Pmty_alias alias }
+        if is_self_reference lid then
+          (* Create a dummy module type to break the circular dependency *)
+          { modtype_decl with pmty_desc = Pmty_signature [] }
+        else
+          (* Just put it as alias *)
+          { modtype_decl with pmty_desc = Pmty_alias alias }
       else
         with_default_loc loc (fun () ->
           match locate_tmodtype_decl ~loc (locate_sig ~loc lid) lid with

--- a/src_test/test_ppx_import.cppo.ml
+++ b/src_test/test_ppx_import.cppo.ml
@@ -50,10 +50,21 @@ let test_self_import ctxt =
   let v : self_t = `OptionA
   in Test_self_import.validate_option v
 
+module type Self_S = [%import: (module Test_self_import.S)]
+
+module Self_M : Self_S = struct
+  let test () = "test"
+end
+
+let test_self_import_module_type ctxt =
+  let m = (module Self_M : Self_S)
+  in Test_self_import.validate_module_type m
+
 let suite = "Test ppx_import" >::: [
-    "test_constr"      >:: test_constr;
-    "test_deriving"    >:: test_deriving;
-    "test_self_import" >:: test_self_import;
+    "test_constr"                  >:: test_constr;
+    "test_deriving"                >:: test_deriving;
+    "test_self_import"             >:: test_self_import;
+    "test_self_import_module_type" >:: test_self_import_module_type;
   ]
 
 let _ =

--- a/src_test/test_self_import.ml
+++ b/src_test/test_self_import.ml
@@ -1,6 +1,12 @@
 type t = [%import: Test_self_import.t]
 
+module type S = [%import: (module Test_self_import.S)]
+
 let validate_option = function
   | `OptionA -> assert true
   | `OptionB -> assert true
   | _ -> assert false
+
+let validate_module_type m =
+  let module M = (val m : S) in
+  assert (M.test () = "test")

--- a/src_test/test_self_import.mli
+++ b/src_test/test_self_import.mli
@@ -3,4 +3,10 @@ type t = [
   | `OptionB
 ]
 
+module type S = sig
+  val test : unit -> string
+end
+
 val validate_option : t -> unit
+val validate_module_type : (module S) -> unit
+


### PR DESCRIPTION
Sorry for overlooking that scenario initially. I took the approach of returning an empty module type signature simply to break the circular reference. I don't foresee any incompatibilities with the various types of module types, but I am no expert :)